### PR TITLE
Fix api headerfile not found error

### DIFF
--- a/cinn/CMakeLists.txt
+++ b/cinn/CMakeLists.txt
@@ -2,6 +2,7 @@ if (WITH_TESTING)
   cc_library(cinn_gtest_main SRCS gtest_main.cc DEPS gtest)
 endif()
 
+add_subdirectory(api)
 add_subdirectory(auto_schedule)
 add_subdirectory(common)
 add_subdirectory(utils)

--- a/cinn/api/CMakeLists.txt
+++ b/cinn/api/CMakeLists.txt
@@ -1,0 +1,1 @@
+core_gather_headers()


### PR DESCRIPTION
Fix the following error when building paddle with CINN

<img width="1386" alt="image" src="https://github.com/jiahy0825/CINN/assets/17810795/0588cf95-1431-47e8-a331-9128fc285026">
